### PR TITLE
fixed dependency

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -29,7 +29,7 @@ Library
         base              >= 4       && < 5  ,
         async             >= 2.0.0   && < 2.1,
         contravariant                   < 0.5,
-        mmorph            >= 1.0.0   && < 1.1,
+        mmorph            >= 1.0.2   && < 1.1,
         pipes             >= 4.0.0   && < 4.2,
         pipes-concurrency >= 2.0.1   && < 2.1,
         transformers      >= 0.2.0.0 && < 0.4 


### PR DESCRIPTION
mmorph 1.0.0 does not export generalize.
