### PR TITLE
Bumped lower bound for pipes to 4.1.0

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -30,7 +30,7 @@ Library
         async             >= 2.0.0   && < 2.1,
         contravariant                   < 0.5,
         mmorph            >= 1.0.2   && < 1.1,
-        pipes             >= 4.0.0   && < 4.2,
+        pipes             >= 4.1.0   && < 4.2,
         pipes-concurrency >= 2.0.1   && < 2.1,
         transformers      >= 0.2.0.0 && < 0.4 
     Exposed-Modules:


### PR DESCRIPTION
requires Pipes.Internal closed which came in 4.1.0.

Contravariant has also been bumped several times recently and I've been relaxing this constraint, but haven't looked into what actually has been changing.
