### PR TITLE
Increase upper bound for contravariant

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -28,7 +28,7 @@ Library
     Build-Depends:
         base              >= 4       && < 5  ,
         async             >= 2.0.0   && < 2.1,
-        contravariant                   < 0.5,
+        contravariant                   < 1.2,
         mmorph            >= 1.0.2   && < 1.1,
         pipes             >= 4.1.0   && < 4.2,
         pipes-concurrency >= 2.0.1   && < 2.1,


### PR DESCRIPTION
Changelogs:
- as of 1.1, semigroups is now a deps see https://github.com/ekmett/contravariant/commit/23431b7e06556e4c3c93778a3b1148d19e191666. I am not sure you will be too happy with this one ?
- as of 1.0, https://github.com/ekmett/contravariant/commit/92e4f79b110ae41db957474c130dfff82fcca4e4

Anyhow, everything does compile fine with contravariant 1.1
