### PR TITLE
Increase upper bounds of async and contravariant

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -27,7 +27,7 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base              >= 4       && < 5  ,
-        async             >= 2.0.0   && < 2.1,
+        async             >= 2.0.0   && < 2.2,
         contravariant                   < 1.4,
         foldl             >= 1.1     && < 1.2,
         managed                         < 1.1,

--- a/mvc.cabal
+++ b/mvc.cabal
@@ -28,7 +28,7 @@ Library
     Build-Depends:
         base              >= 4       && < 5  ,
         async             >= 2.0.0   && < 2.2,
-        contravariant                   < 1.4,
+        contravariant                   < 1.5,
         foldl             >= 1.1     && < 1.2,
         managed                         < 1.1,
         mmorph            >= 1.0.2   && < 1.1,


### PR DESCRIPTION
This brings all dependency upper bounds up to date. I've checked that the project compiles with version `lts-5.5` of stackage, which includes `contravariant-1.4` and `async-2.1.0`.