### PR TITLE
Add Semigroup instances for ghc 8.4, loosen async and mmorph deps

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -36,6 +36,8 @@ Library
         pipes             >= 4.1.7   && < 4.4,
         pipes-concurrency >= 2.0.3   && < 2.1,
         transformers      >= 0.2.0.0 && < 0.6
+    if !impl(ghc >= 8.0)
+        Build-depends: semigroups == 0.18.*
     Exposed-Modules:
         MVC,
         MVC.Prelude

--- a/mvc.cabal
+++ b/mvc.cabal
@@ -28,11 +28,11 @@ Library
     Hs-Source-Dirs: src
     Build-Depends:
         base              >= 4       && < 5  ,
-        async             >= 2.0.0   && < 2.2,
+        async             >= 2.0.0   && < 2.3,
         contravariant                   < 1.5,
         foldl             >= 1.1     && < 1.4,
         managed                         < 1.1,
-        mmorph            >= 1.0.2   && < 1.1,
+        mmorph            >= 1.0.2   && < 1.2,
         pipes             >= 4.1.7   && < 4.4,
         pipes-concurrency >= 2.0.3   && < 2.1,
         transformers      >= 0.2.0.0 && < 0.6


### PR DESCRIPTION
Tested to compile with ghc 8.4.2_rc1, async-2.2.1 and mmorph-1.1.2.

The ghc 8.4 Semigroup suggested changes are documented here:

https://prime.haskell.org/wiki/Libraries/Proposals/SemigroupMonoid#Writingcompatiblecode

Please let me know if you want any changes.  Thanks very much for writing this great library.