### PR TITLE
Sync with foldl>=1.4.0 (premapM)

### DIFF
--- a/mvc.cabal
+++ b/mvc.cabal
@@ -30,7 +30,7 @@ Library
         base              >= 4       && < 5  ,
         async             >= 2.0.0   && < 2.3,
         contravariant                   < 1.5,
-        foldl             >= 1.1     && < 1.4,
+        foldl                          >= 1.4,
         managed                         < 1.1,
         mmorph            >= 1.0.2   && < 1.2,
         pipes             >= 4.1.7   && < 4.4,

--- a/src/MVC.hs
+++ b/src/MVC.hs
@@ -267,7 +267,7 @@ instance Monoid (View a) where
     mappend = (<>)
 
 instance Contravariant View where
-    contramap f (AsFold fold) = AsFold (premapM f fold)
+    contramap f (AsFold fold) = AsFold (premapM (return . f) fold)
 
 -- | Create a `View` from a sink
 asSink :: (a -> IO ()) -> View a


### PR DESCRIPTION
Greetings, 

According to 
http://hackage.haskell.org/package/foldl/changelog

There was a major change in the interface of premapM since foldl-1.4.0:
BREAKING CHANGE: Change type of premapM to accept a monadic function

This small patch fixes the mvc package for the newer foldl. 
Maybe it's a good chance to bump the package version and update it on Hackage.

Have a nice day. Thanks for the packages :)